### PR TITLE
Fix for https://github.com/ewohltman/graphdot/issues/7

### DIFF
--- a/graphdot.go
+++ b/graphdot.go
@@ -22,6 +22,9 @@ var (
 )
 
 func (node *Node) findDeps(ctx *build.Context, pwd string) {
+	if node.Name == "C" {
+		return
+	}
 	pkg, err := ctx.Import(node.Name, pwd, build.ImportComment)
 	if err != nil {
 		log.SetOutput(os.Stderr)


### PR DESCRIPTION
build.Context.Import will return an error if you try to determine imports for the "C" package. This skips processing for that case, as it isn't needed.